### PR TITLE
Change base image to Node 22 and update install command

### DIFF
--- a/webserver/Dockerfile.template
+++ b/webserver/Dockerfile.template
@@ -1,11 +1,6 @@
-# base-image for node on any machine using a template variable,
-# see more about dockerfile templates here: https://www.balena.io/docs/learn/develop/dockerfile/#dockerfile-templates
-# and about balena base images here: https://www.balena.io/docs/reference/base-images/base-images/
-FROM balenalib/%%BALENA_ARCH%%-node:14-buster-run
+FROM node:22-bullseye
 
-# use `install_packages` if you need to install dependencies,
-# for instance if you need git, just uncomment the line below.
-RUN install_packages git nano
+RUN apt-get update && apt-get install -y git nano
 
 # Defines our working directory in container
 WORKDIR /usr/src/app


### PR DESCRIPTION
Updated base image to Node 22 and modified package installation command to eliminate balenalib. change-type: minor